### PR TITLE
Add fallback for calculating MachineID

### DIFF
--- a/sonyflake_test.go
+++ b/sonyflake_test.go
@@ -30,7 +30,10 @@ func init() {
 
 	startTime = toSonyflakeTime(st.StartTime)
 
-	ip, _ := lower16BitPrivateIP()
+	ip, idErr := MachineID()
+	if idErr != nil {
+		panic(idErr)
+	}
 	machineID = uint64(ip)
 }
 


### PR DESCRIPTION
Added more options for allowed private IPv4 space.

If we fail to find a valid IPv4 we try IPv6, and if that fails try a hash of the MAC address.